### PR TITLE
feat: set variables on fail job

### DIFF
--- a/cli/src/fail_job.rs
+++ b/cli/src/fail_job.rs
@@ -24,6 +24,8 @@ pub(crate) struct FailJobArgs {
     // the back off timeout for the next retry
     #[arg(long, required = false, default_value_t = 0)]
     retry_back_off: i64,
+    #[arg(long, required = false, default_value = "")]
+    variables: String,
 }
 
 impl From<&FailJobArgs> for FailJobRequest {
@@ -33,6 +35,7 @@ impl From<&FailJobArgs> for FailJobRequest {
             retries: args.retries,
             error_message: args.error_message.to_owned(),
             retry_back_off: args.retry_back_off,
+            variables: args.variables.clone(),
         }
     }
 }

--- a/client/proto/gateway.proto
+++ b/client/proto/gateway.proto
@@ -273,8 +273,14 @@ message FailJobRequest {
   // this is particularly useful if a job runs out of retries and an incident is raised,
   // as it this message can help explain why an incident was raised
   string errorMessage = 3;
-  // the backoff timeout for the next retry
+  // the backoff timeout (in ms) for the next retry
   int64 retryBackOff = 4;
+  // JSON document that will instantiate the variables at the local scope of the
+  // job's associated task; it must be a JSON object, as variables will be mapped in a
+  // key-value fashion. e.g. { "a": 1, "b": 2 } will create two variables, named "a" and
+  // "b" respectively, with their associated values. [{ "a": 1, "b": 2 }] would not be a
+  // valid argument, as the root of the JSON document is an array and not an object.
+  string variables = 5;
 }
 
 message FailJobResponse {
@@ -403,6 +409,48 @@ message SetVariablesRequest {
 message SetVariablesResponse {
   // the unique key of the set variables command
   int64 key = 1;
+}
+
+message ModifyProcessInstanceRequest {
+  // the key of the process instance that should be modified
+  int64 processInstanceKey = 1;
+  // instructions describing which elements should be activated in which scopes,
+  // and which variables should be created
+  repeated ActivateInstruction activateInstructions = 2;
+  // instructions describing which elements should be terminated
+  repeated TerminateInstruction terminateInstructions = 3;
+
+  message ActivateInstruction {
+    // the id of the element that should be activated
+    string elementId = 1;
+    // the key of the ancestor scope the element instance should be created in;
+    // set to -1 to create the new element instance within an existing element
+    // instance of the flow scope
+    int64 ancestorElementInstanceKey = 2;
+    // instructions describing which variables should be created
+    repeated VariableInstruction variableInstructions = 3;
+  }
+
+  message VariableInstruction {
+    // JSON document that will instantiate the variables for the root variable scope of the
+    // process instance; it must be a JSON object, as variables will be mapped in a
+    // key-value fashion. e.g. { "a": 1, "b": 2 } will create two variables, named "a" and
+    // "b" respectively, with their associated values. [{ "a": 1, "b": 2 }] would not be a
+    // valid argument, as the root of the JSON document is an array and not an object.
+    string variables = 1;
+    // the id of the element in which scope the variables should be created;
+    // leave empty to create the variables in the global scope of the process instance
+    string scopeId = 2;
+  }
+
+  message TerminateInstruction {
+    // the id of the element that should be terminated
+    int64 elementInstanceKey = 1;
+  }
+}
+
+message ModifyProcessInstanceResponse {
+
 }
 
 service Gateway {
@@ -591,5 +639,24 @@ service Gateway {
         - retries is not greater than 0
    */
   rpc UpdateJobRetries (UpdateJobRetriesRequest) returns (UpdateJobRetriesResponse) {
+  }
+
+  /*
+    Modifies the process instance. This is done by activating and/or terminating specific elements of the instance.
+
+    Errors:
+      NOT_FOUND:
+        - no process instance exists with the given key
+
+      FAILED_PRECONDITION:
+        - trying to activate element inside of a multi-instance
+
+      INVALID_ARGUMENT:
+        - activating or terminating unknown element
+        - ancestor of element for activation doesn't exist
+        - scope of variable is unknown
+   */
+  rpc ModifyProcessInstance (ModifyProcessInstanceRequest) returns (ModifyProcessInstanceResponse) {
+
   }
 }


### PR DESCRIPTION
The FailJob RPC now supports passing these variables.

closes #46 